### PR TITLE
FileHelper.GetRelativePath bugfix

### DIFF
--- a/Assets/Lightspeed/Core/IO/FileHelper.cs
+++ b/Assets/Lightspeed/Core/IO/FileHelper.cs
@@ -46,26 +46,24 @@ namespace Rhinox.Lightspeed.IO
         /// <exception cref="InvalidOperationException"></exception>
         public static string GetRelativePath(string path, string parentPath)
         {
-            if (parentPath == path)
-                return "";
-            
             if (string.IsNullOrEmpty(parentPath))
-            {
                 throw new ArgumentNullException(nameof(parentPath));
-            }
 
             if (string.IsNullOrEmpty(path))
-            {
                 throw new ArgumentNullException(nameof(path));
-            }
 
+            // Normalize path separators to Path.DirectorySeparatorChar
+            path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            parentPath = parentPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            
+            if (IsPathEqual(path, parentPath, false))
+                return string.Empty;
+            
             Uri fromUri = new Uri(AppendDirectorySeparatorChar(parentPath)); // Should always be a folder
             Uri toUri = new Uri(path); // Can be a file or folder path
 
-            if (fromUri.Scheme != toUri.Scheme)
-            {
+            if (fromUri.Scheme != toUri.Scheme) // Does not have same root
                 return path;
-            }
 
             Uri relativeUri = fromUri.MakeRelativeUri(toUri);
             string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
@@ -76,6 +74,24 @@ namespace Rhinox.Lightspeed.IO
             }
 
             return relativePath;
+        }
+
+        public static bool IsPathEqual(string path1, string path2, bool convertSlashes = true)
+        {
+            if (path1 == null || path2 == null)
+                return path1 == path2;
+            if (convertSlashes)
+            {
+                // Normalize path separators to Path.DirectorySeparatorChar
+                path1 = path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                path2 = path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            }
+
+            if (path1.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                path1 = path1.Substring(0, path1.Length - 1);
+            if (path2.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                path2 = path2.Substring(0, path2.Length - 1);
+            return path1.Equals(path2);
         }
         
         public static bool IsPathRooted(string path)

--- a/Assets/Lightspeed/Core/IO/FileHelper.cs
+++ b/Assets/Lightspeed/Core/IO/FileHelper.cs
@@ -38,33 +38,33 @@ namespace Rhinox.Lightspeed.IO
         /// <summary>
         /// Creates a relative path from one file or folder to another.
         /// </summary>
-        /// <param name="fromPath">Contains the directory that defines the start of the relative path.</param>
-        /// <param name="toPath">Contains the path that defines the endpoint of the relative path.</param>
+        /// <param name="path">Contains the path that defines the endpoint of the relative path.</param>
+        /// <param name="parentPath">Contains the directory that defines the start of the relative path.</param>
         /// <returns>The relative path from the start directory to the end path.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="fromPath"/> or <paramref name="toPath"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="parentPath"/> or <paramref name="path"/> is <c>null</c>.</exception>
         /// <exception cref="UriFormatException"></exception>
         /// <exception cref="InvalidOperationException"></exception>
-        public static string GetRelativePath(string fromPath, string toPath)
+        public static string GetRelativePath(string path, string parentPath)
         {
-            if (fromPath == toPath)
+            if (parentPath == path)
                 return "";
             
-            if (string.IsNullOrEmpty(fromPath))
+            if (string.IsNullOrEmpty(parentPath))
             {
-                throw new ArgumentNullException(nameof(fromPath));
+                throw new ArgumentNullException(nameof(parentPath));
             }
 
-            if (string.IsNullOrEmpty(toPath))
+            if (string.IsNullOrEmpty(path))
             {
-                throw new ArgumentNullException(nameof(toPath));
+                throw new ArgumentNullException(nameof(path));
             }
 
-            Uri fromUri = new Uri(fromPath);
-            Uri toUri = new Uri(AppendDirectorySeparatorChar(toPath));
+            Uri fromUri = new Uri(AppendDirectorySeparatorChar(parentPath)); // Should always be a folder
+            Uri toUri = new Uri(path); // Can be a file or folder path
 
             if (fromUri.Scheme != toUri.Scheme)
             {
-                return toPath;
+                return path;
             }
 
             Uri relativeUri = fromUri.MakeRelativeUri(toUri);
@@ -214,7 +214,8 @@ namespace Rhinox.Lightspeed.IO
         {
             // Append a slash only if the path is a directory and does not have a slash.
             if (!Path.HasExtension(path) &&
-                !path.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                !path.EndsWith(Path.DirectorySeparatorChar.ToString()) &&
+                !path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
             {
                 return path + Path.DirectorySeparatorChar;
             }

--- a/Assets/Lightspeed/package.json
+++ b/Assets/Lightspeed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.lightspeed",
-  "displayName": "Lightspeed (Rhinox Module)",
-  "version": "1.1.0",
+  "displayName": "Lightspeed - Coding Utility Library",
+  "version": "1.1.1",
   "unity": "2019.3",
   "description": "Coding extensions library: New basic datatypes, static helper methods and extensions on Unity datatypes ",
   "keywords": [

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d4636c330f86284fbdb1cf60d20a988
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/FileHelperTests.cs
+++ b/Assets/Tests/FileHelperTests.cs
@@ -1,11 +1,7 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
 using Rhinox.Lightspeed;
 using Rhinox.Lightspeed.IO;
-using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace Tests
 {
@@ -27,14 +23,43 @@ namespace Tests
         [Test]
         public void FindSubFolderTest()
         {
-            AssertRelativePath("D:/Test/Foobar",   "D:/Test",     "Foobar\\");
+            AssertRelativePath("D:/Test/Foobar",   "D:/Test",     "Foobar");
+            AssertRelativePath("D:/Test/Foobar",   "D:/Test",     "Foobar");
+            AssertRelativePath("D:/Test\\Foobar",  "D:\\Test",    "Foobar");
+            AssertRelativePath("D:/Test/Foobar",   "D:\\Test/",   "Foobar");
+            AssertRelativePath("D:\\Test/Foobar",  "D:\\Test/",   "Foobar");
+            AssertRelativePath("D:\\Test/Foobar",  "D:\\Test\\",  "Foobar");
+            
             AssertRelativePath("D:/Test/Foobar/",  "D:/Test/",    "Foobar\\");
-            AssertRelativePath("D:/Test/Foobar",   "D:/Test",     "Foobar\\");
             AssertRelativePath("D:/Test/Foobar\\", "D:/Test/",    "Foobar\\");
-            AssertRelativePath("D:/Test\\Foobar",  "D:\\Test",    "Foobar\\");
-            AssertRelativePath("D:/Test/Foobar",   "D:\\Test/",   "Foobar\\");
-            AssertRelativePath("D:\\Test/Foobar",  "D:\\Test/",   "Foobar\\");
-            AssertRelativePath("D:\\Test/Foobar",  "D:\\Test\\",  "Foobar\\");
+        }
+        
+        [Test]
+        public void FindSubFolderUpDownTest1()
+        {
+            AssertRelativePath("D:/Test/Bar/Foobar",   "D:/Test/Foo/",     "..\\Bar\\Foobar");
+            AssertRelativePath("D:/Test/Bar/Foobar",   "D:/Test/Foo\\",    "..\\Bar\\Foobar");
+            AssertRelativePath("D:/Test/Bar/Foobar",   "D:\\Test/Foo/",    "..\\Bar\\Foobar");
+            AssertRelativePath("D:\\Test/Bar/Foobar",  "D:\\Test\\Foo\\",  "..\\Bar\\Foobar");
+            AssertRelativePath("D:/Test\\Bar/Foobar",  "D:\\Test/Foo",     "..\\Bar\\Foobar");
+            AssertRelativePath("D:\\Test/Bar/Foobar",  "D:\\Test/Foo",     "..\\Bar\\Foobar");
+            
+            AssertRelativePath("D:/Test/Bar/Foobar/",  "D:/Test/Foo",      "..\\Bar\\Foobar\\");
+            AssertRelativePath("D:/Test/Bar/Foobar\\", "D:/Test/Foo",      "..\\Bar\\Foobar\\");
+        }
+        
+        [Test]
+        public void FindSubFolderUpDownTest2()
+        {
+            AssertRelativePath("D:/Test/Foo",      "D:/Test/Bar/Foobar/",  "..\\..\\Foo");
+            AssertRelativePath("D:/Test/Foo",      "D:/Test/Bar/Foobar\\", "..\\..\\Foo");
+            AssertRelativePath("D:\\Test/Foo",     "D:/Test\\Bar/Foobar",  "..\\..\\Foo");
+            AssertRelativePath("D:\\Test/Foo",     "D:\\Test/Bar/Foobar",  "..\\..\\Foo");
+            
+            AssertRelativePath("D:/Test/Foo/",     "D:/Test/Bar/Foobar",   "..\\..\\Foo\\");
+            AssertRelativePath("D:\\Test/Foo/",    "D:/Test/Bar/Foobar",   "..\\..\\Foo\\");
+            AssertRelativePath("D:/Test/Foo\\",    "D:/Test/Bar/Foobar",   "..\\..\\Foo\\");
+            AssertRelativePath("D:\\Test\\Foo\\",  "D:\\Test/Bar/Foobar",  "..\\..\\Foo\\");
         }
 
         [Test]

--- a/Assets/Tests/FileHelperTests.cs
+++ b/Assets/Tests/FileHelperTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Rhinox.Lightspeed;
+using Rhinox.Lightspeed.IO;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class FileHelperTests
+    {
+        [Test]
+        public void EqualFolderTest()
+        {
+            AssertRelativePath("D:/Test", "D:/Test", string.Empty);
+            AssertRelativePath("D:/Test", "D:/Test/", string.Empty);
+            AssertRelativePath("D:/Test/", "D:/Test", string.Empty);
+            AssertRelativePath("D:/Test/", "D:/Test/", string.Empty);
+            AssertRelativePath("D:/Test", "D:\\Test", string.Empty);
+            AssertRelativePath("D:/Test", "D:\\Test/", string.Empty);
+            AssertRelativePath("D:\\Test", "D:\\Test/", string.Empty);
+            AssertRelativePath("D:\\Test", "D:\\Test\\", string.Empty);
+        }
+        
+        [Test]
+        public void FindSubFolderTest()
+        {
+            AssertRelativePath("D:/Test/Foobar",   "D:/Test",     "Foobar\\");
+            AssertRelativePath("D:/Test/Foobar/",  "D:/Test/",    "Foobar\\");
+            AssertRelativePath("D:/Test/Foobar",   "D:/Test",     "Foobar\\");
+            AssertRelativePath("D:/Test/Foobar\\", "D:/Test/",    "Foobar\\");
+            AssertRelativePath("D:/Test\\Foobar",  "D:\\Test",    "Foobar\\");
+            AssertRelativePath("D:/Test/Foobar",   "D:\\Test/",   "Foobar\\");
+            AssertRelativePath("D:\\Test/Foobar",  "D:\\Test/",   "Foobar\\");
+            AssertRelativePath("D:\\Test/Foobar",  "D:\\Test\\",  "Foobar\\");
+        }
+
+        [Test]
+        public void FolderToFileTests()
+        {
+            AssertRelativePath("D:/Test/foobar.txt",   "D:/Test",     "foobar.txt");
+            AssertRelativePath("D:/Test/foobar.txt",   "D:/Test/",    "foobar.txt");
+            AssertRelativePath("D:/Test/foobar.txt",   "D:/Test",     "foobar.txt");
+            AssertRelativePath("D:/Test/foobar.txt",   "D:/Test/",    "foobar.txt");
+            AssertRelativePath("D:/Test\\foobar.txt",  "D:\\Test",    "foobar.txt");
+            AssertRelativePath("D:/Test/foobar.txt",   "D:\\Test/",   "foobar.txt");
+            AssertRelativePath("D:\\Test/foobar.txt",  "D:\\Test/",   "foobar.txt");
+            AssertRelativePath("D:\\Test/foobar.txt",  "D:\\Test\\",  "foobar.txt");
+        }
+
+        public void AssertRelativePath(string fromPath, string parentPath, string expectedAnswer)
+        {
+            string relativePath = FileHelper.GetRelativePath(fromPath, parentPath);
+            Assert.True((relativePath.IsNullOrEmpty() && expectedAnswer.IsNullOrEmpty()) || relativePath == expectedAnswer, 
+                $"'{parentPath}' => '{fromPath}' yielded '{relativePath}', expected '{expectedAnswer}'");
+        }
+    }
+}

--- a/Assets/Tests/FileHelperTests.cs.meta
+++ b/Assets/Tests/FileHelperTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e427823d8b2f4a9489db7b6b55722b34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Tests.asmdef
+++ b/Assets/Tests/Tests.asmdef
@@ -1,0 +1,21 @@
+{
+    "name": "Tests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "com.rhinox.open.lightspeed"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Tests.asmdef.meta
+++ b/Assets/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3a3cd49f997291f44a8c3609dc3448ba
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lightspeed - Utility Library for Unity
+# Lightspeed - Coding Utility Library for Unity
 
 [![openupm](https://img.shields.io/npm/v/com.rhinox.open.lightspeed?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/com.rhinox.open.lightspeed/)
 


### PR DESCRIPTION
API Update (changed to wrong argument order by 1.1.0 upgrade)
Fixes for paths ending in DirectorySeparatorChar
Added UnitTests for this case