### PR TITLE
Serialize fixes

### DIFF
--- a/Assets/Lightspeed/Core/Attributes/RefactoringOldNamespaceAttribute.cs
+++ b/Assets/Lightspeed/Core/Attributes/RefactoringOldNamespaceAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Rhinox.Lightspeed
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class | AttributeTargets.Enum)]
     public sealed class RefactoringOldNamespaceAttribute : Attribute
     {
         public string PreviousNamespace { get; }

--- a/Assets/Lightspeed/Core/IO/FileHelper.cs
+++ b/Assets/Lightspeed/Core/IO/FileHelper.cs
@@ -199,7 +199,7 @@ namespace Rhinox.Lightspeed.IO
                         var subfolders = Directory.GetDirectories(folder);
                         foldersToProcess.AddRange(subfolders);
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
                         //log if you're interested
                     }
@@ -211,7 +211,7 @@ namespace Rhinox.Lightspeed.IO
                 {
                     files = Directory.GetFiles(folder, searchPattern, SearchOption.TopDirectoryOnly).ToList();
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     //log if you're interested
                 }

--- a/Assets/Lightspeed/Unity/Data/Axis.cs
+++ b/Assets/Lightspeed/Unity/Data/Axis.cs
@@ -4,6 +4,7 @@ using Sirenix.OdinInspector;
 
 namespace Rhinox.Lightspeed
 {
+    [RefactoringOldNamespace("Rhinox.Utilities")]
     [EnumToggleButtons, Flags]
     public enum Axis
     {

--- a/Assets/Lightspeed/Unity/Data/RangeFloat.cs
+++ b/Assets/Lightspeed/Unity/Data/RangeFloat.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 namespace Rhinox.Lightspeed
 {
+    [RefactoringOldNamespace("Rhinox.Utilities")]
     public class RangeFloat
     {
         public float Start;

--- a/Assets/Lightspeed/Unity/Data/TransformState.cs
+++ b/Assets/Lightspeed/Unity/Data/TransformState.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace Rhinox.Lightspeed
 {
+    [RefactoringOldNamespace("Rhinox.Utilities")]
     [Serializable]
     public struct TransformState
     {

--- a/Assets/Lightspeed/Unity/Data/WindDirection.cs
+++ b/Assets/Lightspeed/Unity/Data/WindDirection.cs
@@ -3,6 +3,7 @@ using Sirenix.OdinInspector;
 
 namespace Rhinox.Lightspeed
 {
+    [RefactoringOldNamespace("Rhinox.Utilities")]
     [EnumToggleButtons, Flags]
     public enum WindDirection
     {

--- a/Assets/Lightspeed/Unity/Serialization/SerializableFieldInfo.cs
+++ b/Assets/Lightspeed/Unity/Serialization/SerializableFieldInfo.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 namespace Rhinox.Lightspeed
 {
+    [RefactoringOldNamespace("Rhinox.Utilities")]
     [Serializable]
     public class SerializableFieldInfo : SerializableMemberInfo
     {

--- a/Assets/Lightspeed/Unity/Serialization/SerializableGuid.cs
+++ b/Assets/Lightspeed/Unity/Serialization/SerializableGuid.cs
@@ -10,6 +10,7 @@ namespace Rhinox.Lightspeed
         SerializableGuid ID { get; }
     }
     
+    [RefactoringOldNamespace("Rhinox.Utilities")]
     [Serializable]
     public class SerializableGuid : IEquatable<SerializableGuid>
     {

--- a/Assets/Lightspeed/Unity/Serialization/SerializablePropertyInfo.cs
+++ b/Assets/Lightspeed/Unity/Serialization/SerializablePropertyInfo.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 
 namespace Rhinox.Lightspeed
 {
+    [RefactoringOldNamespace("Rhinox.Utilities")]
     [Serializable]
     public class SerializablePropertyInfo : SerializableMemberInfo
     {

--- a/Assets/Lightspeed/package.json
+++ b/Assets/Lightspeed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.lightspeed",
   "displayName": "Lightspeed - Coding Utility Library",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "unity": "2019.3",
   "description": "Coding extensions library: New basic datatypes, static helper methods and extensions on Unity datatypes ",
   "keywords": [


### PR DESCRIPTION
### Changes
- RefactoringOldNamespaceAttribute is now applicable to Enum and Struct
- Added RefactoringOldNamespaceAttribute to Axis, RangeFloat, TransformState, WindDirection
- Added RefactoringOldNamespaceAttribute to SerializableFieldInfo, SerializablePropertyInfo, SerializableGuid
- Removed compiler warnings