### PR TITLE
[v1.2.3] Fix for build errors Texture2D transparency

### DIFF
--- a/Assets/Lightspeed/Unity/Helpers/Utility.Textures.cs
+++ b/Assets/Lightspeed/Unity/Helpers/Utility.Textures.cs
@@ -35,7 +35,9 @@ namespace Rhinox.Lightspeed
                 return tex;
             
             Texture2D paddedTex = new Texture2D(1, 1, tex.format, tex.mipmapCount > 0) {
+#if UNITY_EDITOR
                 alphaIsTransparency = tex.alphaIsTransparency,
+#endif
             };
 
             var color = Color.clear;

--- a/Assets/Lightspeed/package.json
+++ b/Assets/Lightspeed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.lightspeed",
   "displayName": "Lightspeed - Coding Utility Library",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "unity": "2019.3",
   "description": "Coding extensions library: New basic datatypes, static helper methods and extensions on Unity datatypes ",
   "keywords": [


### PR DESCRIPTION
### Fixes
- Removed alphaIsTransparency for runtime builds on Texture2D pad