### PR TITLE
Fix for Utility.Destroy missing return statement

### DIFF
--- a/Assets/Lightspeed/Unity/Helpers/Utility.RuntimeEditor.cs
+++ b/Assets/Lightspeed/Unity/Helpers/Utility.RuntimeEditor.cs
@@ -27,7 +27,12 @@ namespace Rhinox.Lightspeed
         public static void Destroy(Object o, bool immediate = false)
         {
             if (o == null) return;
-            if (immediate) Object.DestroyImmediate(o);
+            if (immediate)
+            {
+                Object.DestroyImmediate(o);
+                return;
+            }
+            
 #if UNITY_EDITOR
             if (!Application.isPlaying)
                 Object.DestroyImmediate(o);

--- a/Assets/Lightspeed/package.json
+++ b/Assets/Lightspeed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.lightspeed",
   "displayName": "Lightspeed - Coding Utility Library",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "unity": "2019.3",
   "description": "Coding extensions library: New basic datatypes, static helper methods and extensions on Unity datatypes ",
   "keywords": [


### PR DESCRIPTION
### Fixes
- Added missing return statement in Utility.Destroy on immediate=true