### PR TITLE
v1.2.6

### DIFF
--- a/Assets/Lightspeed/package.json
+++ b/Assets/Lightspeed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.lightspeed",
   "displayName": "Lightspeed - Coding Utility Library",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "unity": "2019.3",
   "description": "Coding extensions library: New basic datatypes, static helper methods and extensions on Unity datatypes ",
   "keywords": [


### PR DESCRIPTION
### Performance Fixes
- BoundsExtensions.GetCorners
- BoundsExtensions.GetLocalBounds for MeshRenderer (calcUsingVerts)

### Added
- BoundsExtensions.GetCornersTransformed, a performant GetCorners using a Matrix4x4 