### PR TITLE
v1.2.8 Ftr/additional extensions

### DIFF
--- a/Assets/Lightspeed/Unity/Extensions/BoundsExtensions.cs
+++ b/Assets/Lightspeed/Unity/Extensions/BoundsExtensions.cs
@@ -391,5 +391,20 @@ namespace Rhinox.Lightspeed
 
 			return b;
 		}
+
+		public static void CenterObjectBoundsOnPosition(this GameObject go, Vector3 position, Quaternion? rotation = null)
+		{
+			var localBounds = go.GetObjectLocalBounds();
+			Vector3 localPositionOfCenter = localBounds.center;
+
+			Vector3 globalPositionOfCenter = go.transform.TransformPoint(localPositionOfCenter);
+			Vector3 offset = go.transform.position - globalPositionOfCenter;
+
+			Vector3 rotatedOffset = (rotation ?? Quaternion.identity) * offset;
+			
+			if (rotation != null)
+				TransformExtensions.RotateAround(go.transform, globalPositionOfCenter, rotation.Value);
+			go.transform.position = position + rotatedOffset;
+		}
 	}
 }

--- a/Assets/Lightspeed/Unity/Helpers/Utility.Packages.cs
+++ b/Assets/Lightspeed/Unity/Helpers/Utility.Packages.cs
@@ -32,12 +32,14 @@ namespace Rhinox.Lightspeed
 
         public static string GetPathRelativeToProject(string path)
         {
+            if (!Path.IsPathRooted(path))
+                path = Path.GetFullPath(path);
             var pathUri = new Uri(path);
             return ApplicationFolderUri.MakeRelativeUri(pathUri).ToString();
         }
 
         /// <summary>
-        /// Get a valid Asset path from a 'Libarary/PackageCache/' path
+        /// Get a valid Asset path from a 'Library/PackageCache/' path
         /// </summary>
         public static string ParsePackagePath(string absolutePath)
         {

--- a/Assets/Lightspeed/Unity/Helpers/Utility.Textures.cs
+++ b/Assets/Lightspeed/Unity/Helpers/Utility.Textures.cs
@@ -1,11 +1,31 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 
 namespace Rhinox.Lightspeed
 {
     public static partial class Utility
     {
         private static Dictionary<Color, Texture2D> _textureByColor;
+
+        /// <summary>
+        /// Copies a texture (readable or not) into CPU memory of a new texture.
+        /// Apply needs to be called for it to be usable in GPU.
+        /// </summary>
+        public static Texture2D CopyTextureCPU(Texture tex, TextureCreationFlags flags = TextureCreationFlags.None)
+        {
+            var rt = RenderTexture.GetTemporary(tex.width, tex.height, 0, tex.graphicsFormat);
+            var copy = new Texture2D(tex.width, tex.height, tex.graphicsFormat, flags);
+            Graphics.Blit(tex, rt);
+
+            var oldRt = RenderTexture.active;
+            RenderTexture.active = rt;
+            copy.ReadPixels(new Rect(0, 0, tex.width, tex.height), 0, 0);
+            RenderTexture.active = oldRt;
+            RenderTexture.ReleaseTemporary(rt);
+
+            return copy;
+        }
         
         public static Texture2D GetColorTexture(Color color)
         {

--- a/Assets/Lightspeed/package.json
+++ b/Assets/Lightspeed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.lightspeed",
   "displayName": "Lightspeed - Coding Utility Library",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "unity": "2019.3",
   "description": "Coding extensions library: New basic datatypes, static helper methods and extensions on Unity datatypes ",
   "keywords": [

--- a/Assets/Tests/SetToPosition.cs
+++ b/Assets/Tests/SetToPosition.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+using Rhinox.Lightspeed;
+
+namespace Tests
+{
+    public class SetToPosition : MonoBehaviour
+    {
+        public Vector3 Pos;
+        public Vector3 Euler;
+
+        [ContextMenu("Set")]
+        public void SetPosition()
+        {
+            var quat = Quaternion.Euler(Euler);
+            gameObject.CenterObjectBoundsOnPosition(Pos, quat);
+        }
+    }
+}

--- a/Assets/Tests/SetToPosition.cs.meta
+++ b/Assets/Tests/SetToPosition.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 98f4749eb2094e69a9b0d6d8d00503fe
+timeCreated: 1669204603


### PR DESCRIPTION
### Added
- CenterObjectBoundsOnPosition extension method for GameObject
- Utility.CopyTextureCPU: Copies a texture (readable or not) into CPU memory of a new texture.

### Fixed
- GetPathRelativeToProject now allows non-rooted paths